### PR TITLE
Cleanup generation of HTML for request page

### DIFF
--- a/reg_form.html
+++ b/reg_form.html
@@ -5,8 +5,19 @@
   <meta name="generator" content=
   "HTML Tidy for HTML5 for Linux version 5.2.0" />
   <title>Join TriLUG!</title>
+  <style>
+    .error {
+      color: red;
+    }
+  </style>
 </head>
 <body>
+  <div id="missing" style="display: none">
+    <p><strong>Error:  Required field(s) not filled out.</strong></p>
+  </div>
+  <div class="error">
+    <p id="exception"></p>
+  </div>
   <form method="post" action="#">
     <div align="center">
       <div style="width:60%">
@@ -20,23 +31,23 @@
       </div>
       <hr width="50%" />
       <table cellspacing="1" cellpadding="1" border="0">
-        <tr>
-          <td align="right">First Name:</td>
-          <td align="left"><input type="text" name="first" /></td>
-          <td align="right">Last Name:</td>
-          <td align="left"><input type="text" name="last" /></td>
-        </tr>
-        <tr>
-          <td align="right">Street Address 1:</td>
-          <td align="left" colspan="3"><input type="text" name=
-          "addr1" /></td>
-        </tr>
-        <tr>
-          <td align="right">Street Address 2
-          <strong>[*]</strong>:</td>
-          <td align="left" colspan="3"><input type="text" name=
-          "addr2" /></td>
-        </tr>
+          <tr>
+              <td align="right">First Name:</td>
+              <td align="left"><input type="text" name="first" /></td>
+              <td align="right">Last Name:</td>
+              <td align="left"><input type="text" name="last" /></td>
+          </tr>
+          <tr>
+              <td align="right">Street Address 1:</td>
+              <td align="left" colspan="3"><input type="text" name=
+              "addr1" /></td>
+          </tr>
+          <tr>
+              <td align="right">Street Address 2
+                  <strong>[*]</strong>:</td>
+              <td align="left" colspan="3"><input type="text" name=
+              "addr2" /></td>
+          </tr>
         <tr>
           <td align="right" colspan="2">City: <input type="text"
           name="city" /></td>
@@ -72,6 +83,14 @@
       </table>
     </div>
   </form>
+
+  <div id="success" style="display: none">
+    <p>
+      Thank you for requesting membership in TriLUG!  Be sure to come to a
+      meeting in person in order to complete the process.  See you there!
+    </p>
+  </div>
+
   <hr width="50%" />
   <div align="center">
     Reload the <a href="/cgi-bin/{}">form</a> <strong>|</strong>

--- a/reg_form.html
+++ b/reg_form.html
@@ -1,4 +1,4 @@
-header = '''<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html>
 <head>
@@ -6,23 +6,6 @@ header = '''<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http
 </head>
 
 <body>
-'''
-
-footer = '''
-<p>
-<hr width="50%">
-</p>
-<div align="center">
-Reload the <a href="/cgi-bin/{}">form</a>
-<strong>|</strong>
-Back to <a href="/">TriLUG</a>
-</div>
-
-</body>
-</html>
-'''
-
-full_form = '''
 
 <form method="POST" action="#">
 <div align="center">
@@ -74,5 +57,14 @@ process your request and get you set up in no time.</p>
 </div>
 </form>
 
-'''
+<p>
+<hr width="50%">
+</p>
+<div align="center">
+Reload the <a href="/cgi-bin/{}">form</a>
+<strong>|</strong>
+Back to <a href="/">TriLUG</a>
+</div>
 
+</body>
+</html>

--- a/reg_form.html
+++ b/reg_form.html
@@ -1,70 +1,81 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-
-<html>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <title>Join TriLUG!</title>
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Linux version 5.2.0" />
+  <title>Join TriLUG!</title>
 </head>
-
 <body>
-
-<form method="POST" action="#">
-<div align="center">
-
-<div style="width:60%">
-<p>Thank you for your interest in TriLUG!  The process of becoming a member is
-very simple.  Just fill out and submit the form below, and then talk to one of
-the members of the Steering Committee at the next meeting you attend (or the
-same one, if you're filling this out while you're there).  They can quickly
-process your request and get you set up in no time.</p>
-</div>
-
-<hr width="50%">
-
-<table cellspacing="1" cellpadding="1" border="0">
-<tr>
-<td align="right">First Name:</td><td align="left"><input type="text" name="first"></td>
-<td align="right">Last Name:</td><td align="left"><input type="text" name="last"></td>
-</tr>
-<tr>
-<td align="right">Street Address 1:</td>
-<td align="left" colspan=3><input type="text" name="addr1"></td>
-</tr>
-<tr>
-<td align="right">Street Address 2 <strong>[*]</strong>:</td>
-<td align="left" colspan=3><input type="text" name="addr2"></td>
-</tr>
-<tr>
-<td align="right" colspan=2>City: <input type="text" name="city"></td>
-<td align="left">&nbsp;&nbsp;State: <input type="text" name="state" size=2></td>
-<td align="left">&nbsp;&nbsp;Zip: <input type="text" name ="zipcode" size=5></td>
-</tr>
-<tr>
-<td align="right">Email:</td>
-<td align="left" colspan=3><input type="text" name="email"></td>
-</tr>
-<tr>
-<td align="right">Preferred User ID <strong>[*]</strong>:</td>
-<td align="left" colspan=3><input type="text" name="username"></td>
-</tr>
-<tr><td align="center" colspan=4></br><strong>[*]</strong> Optional fields.  You can leave the User ID blank if you don't want shell or email.</td></tr>
-<tr>
-<td></td>
-<td align="center"></br><input type="submit" value="Submit"></td>
-<td align="center"></br><input type="reset" value="Clear"></td>
-<td></td>
-</tr>
-</table>
-</div>
-</form>
-
-<p>
-<hr width="50%">
-</p>
-<div align="center">
-Reload the <a href="/cgi-bin/{}">form</a>
-<strong>|</strong>
-Back to <a href="/">TriLUG</a>
-</div>
-
+  <form method="post" action="#">
+    <div align="center">
+      <div style="width:60%">
+        <p>Thank you for your interest in TriLUG! The process of
+        becoming a member is very simple. Just fill out and submit
+        the form below, and then talk to one of the members of the
+        Steering Committee at the next meeting you attend (or the
+        same one, if you're filling this out while you're there).
+        They can quickly process your request and get you set up in
+        no time.</p>
+      </div>
+      <hr width="50%" />
+      <table cellspacing="1" cellpadding="1" border="0">
+        <tr>
+          <td align="right">First Name:</td>
+          <td align="left"><input type="text" name="first" /></td>
+          <td align="right">Last Name:</td>
+          <td align="left"><input type="text" name="last" /></td>
+        </tr>
+        <tr>
+          <td align="right">Street Address 1:</td>
+          <td align="left" colspan="3"><input type="text" name=
+          "addr1" /></td>
+        </tr>
+        <tr>
+          <td align="right">Street Address 2
+          <strong>[*]</strong>:</td>
+          <td align="left" colspan="3"><input type="text" name=
+          "addr2" /></td>
+        </tr>
+        <tr>
+          <td align="right" colspan="2">City: <input type="text"
+          name="city" /></td>
+          <td align="left">&nbsp;&nbsp;State: <input type="text"
+          name="state" size="2" /></td>
+          <td align="left">&nbsp;&nbsp;Zip: <input type="text"
+          name="zipcode" size="5" /></td>
+        </tr>
+        <tr>
+          <td align="right">Email:</td>
+          <td align="left" colspan="3"><input type="text" name=
+          "email" /></td>
+        </tr>
+        <tr>
+          <td align="right">Preferred User ID
+          <strong>[*]</strong>:</td>
+          <td align="left" colspan="3"><input type="text" name=
+          "username" /></td>
+        </tr>
+        <tr>
+          <td align="center" colspan="4"><br />
+          <strong>[*]</strong> Optional fields. You can leave the
+          User ID blank if you don't want shell or email.</td>
+        </tr>
+        <tr>
+          <td></td>
+          <td align="center"><br />
+          <input type="submit" value="Submit" /></td>
+          <td align="center"><br />
+          <input type="reset" value="Clear" /></td>
+          <td></td>
+        </tr>
+      </table>
+    </div>
+  </form>
+  <hr width="50%" />
+  <div align="center">
+    Reload the <a href="/cgi-bin/{}">form</a> <strong>|</strong>
+    Back to <a href="/">TriLUG</a>
+  </div>
 </body>
 </html>

--- a/reg_form.py
+++ b/reg_form.py
@@ -24,7 +24,7 @@ Back to <a href="/">TriLUG</a>
 
 full_form = '''
 
-<form method="POST" action="/cgi-bin/request_membership">
+<form method="POST" action="#">
 <div align="center">
 
 <div style="width:60%">

--- a/request_membership
+++ b/request_membership
@@ -22,8 +22,11 @@ cgitb.enable(display=0, logdir=debugdir)
 reg_page = fromstring(open('reg_form.html', 'r').read())
 
 the_form = cgi.FieldStorage()
+fields = {}
+for k in the_form.keys():
+    fields[k] = the_form.getfirst(k)
 
-#reg_page.forms[0].fields.update()
+reg_page.forms[0].fields.update(fields)
 
 if "email" in the_form:
     try:

--- a/request_membership
+++ b/request_membership
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import sys
+sys.stdout = open(sys.stdout.fileno(), mode='w', encoding='utf-8', buffering=1)
+
 import cgi
 import cgitb
 import html
@@ -53,6 +56,6 @@ The registration system is currently unavailable.  Please try back later.''')
 <p>Thank you for requesting membership in TriLUG!  Be sure to come to a</br>
 meeting in person in order to complete the process.  See you there!</p>'''
 
-print('''Content-type: text/html
+print('''Content-type: text/html; charset=utf-8
 
 ''', tostring(reg_page, encoding="unicode"))

--- a/request_membership
+++ b/request_membership
@@ -5,7 +5,8 @@ import cgitb
 import html
 import os.path
 
-import reg_form
+from lxml.html import fromstring,tostring
+
 import reg_scrub
 import register
 
@@ -15,18 +16,13 @@ from reg_request_db import RegDb
 debugdir = '/tmp'
 cgitb.enable(display=0, logdir=debugdir)
 
+reg_page = fromstring(open('reg_form.html', 'r').read())
+
 the_form = cgi.FieldStorage()
 
-print('''Content-type: text/html
+#reg_page.forms[0].fields.update()
 
-{}'''.format(reg_form.header))
-
-if "email" not in the_form:
-    print(reg_form.full_form)
-
-else:
-    print('<div align="center">')
-
+if "email" in the_form:
     try:
         reg_db = RegDb(register.database)
 
@@ -53,10 +49,10 @@ The registration system is currently unavailable.  Please try back later.''')
                 print('<p><strong>Error: {err}</strong></p>'.format(err = str(e)))
 
             else:
-                print('''
+                msg = '''
 <p>Thank you for requesting membership in TriLUG!  Be sure to come to a</br>
-meeting in person in order to complete the process.  See you there!</p>''')
+meeting in person in order to complete the process.  See you there!</p>'''
 
-    print('</div>')
+print('''Content-type: text/html
 
-print(reg_form.footer.format(os.path.basename(__file__)))
+''', tostring(reg_page, encoding="unicode"))

--- a/request_membership
+++ b/request_membership
@@ -17,7 +17,7 @@ from member import Member
 from reg_request_db import RegDb
 
 debugdir = '/tmp'
-cgitb.enable(display=0, logdir=debugdir)
+cgitb.enable(display=1, logdir=debugdir)
 
 reg_page = fromstring(open('reg_form.html', 'r').read())
 
@@ -26,16 +26,17 @@ fields = {}
 for k in the_form.keys():
     fields[k] = the_form.getfirst(k)
 
-reg_page.forms[0].fields.update(fields)
+reg_form = reg_page.forms[0]
+reg_form.fields.update(fields)
+
+err_elem = reg_page.xpath('//*[@id="exception"]')[0]
 
 if "email" in the_form:
     try:
         reg_db = RegDb(register.database)
 
     except:
-        print('''<h1>Internal Error</h1>
-
-The registration system is currently unavailable.  Please try back later.''')
+        err_elem.text = 'The registration system is currently unavailable.  Please try back later.'
 
     else:
         try:
@@ -45,19 +46,18 @@ The registration system is currently unavailable.  Please try back later.''')
                             and reg_scrub.val_ok(the_form[var].value)))
 
         except TypeError:
-            print('<p><strong>Error:  Required field(s) not filled out.</strong></p>')
+            reg_page.xpath('//*[@id="missing"]')[0].set('style', '')
 
         else:
             try:
                 reg_db.insert(the_member)
 
             except RuntimeError as e:
-                print('<p><strong>Error: {err}</strong></p>'.format(err = str(e)))
+                err_elem.text = 'Err: {err}'.format(err = str(e))
 
             else:
-                msg = '''
-<p>Thank you for requesting membership in TriLUG!  Be sure to come to a</br>
-meeting in person in order to complete the process.  See you there!</p>'''
+                reg_page.xpath('//*[@id="success"]')[0].set('style', '')
+                reg_form.clear()
 
 print('''Content-type: text/html; charset=utf-8
 


### PR DESCRIPTION
This switches the source of HTML form to an actual `.html` file rather than using a python module with several large strings. This allows syntax highlighting to be used when editing the source.

The success message and error messages have also been moved into the HTML source (other than in one case where it inserts the textual representation of an exception). If the registration appeared to succeed, the `<form>` element is simply emptied so that it will not be displayed.

Besides cleaning up the code, there is already a usability improvement.  Now if an error is found the values entered into the form are preserved rather than forcing the user to go back to the previous page.

Next step will be to bring HTML into this century. Currently it's only slightly changed from what was in the `.py` file.
